### PR TITLE
[DO NOT MERGE] add python3 deps and fix python requests dep

### DIFF
--- a/apb.spec
+++ b/apb.spec
@@ -39,17 +39,21 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 Requires: python3-PyYAML >= 3.10
 Requires: python3-PyYAML < 4
+Requires: python3-docker >= 2.1.0
+Requires: python3-docker < 3.0.0
+Requires: python3-jinja2 >= 2.7.2
+Requires: python3-requests >= 2.10.0
 %else
 BuildRequires: python-devel
 BuildRequires: python-setuptools
 Requires: PyYAML >= 3.10
 Requires: PyYAML < 4
-%endif
-Requires: docker
 Requires: python-docker >= 2.1.0
 Requires: python-docker < 3.0.0
 Requires: python-jinja2 >= 2.7.2
-Requires: python-requests2 >= 2.10.0
+Requires: python-requests >= 2.10.0
+%endif
+Requires: docker
 
 %description
 Ansible Playbook Bundle (APB) is a lightweight application definition (meta-containers). APB


### PR DESCRIPTION
@dymurray are we able to drop python-requests to 2.6.0 to satisfy the dependency using the package already available in RHEL/CentOS 7? If so I'll amend this PR to drop the version in the requirements file and the rpm spec.