### PR TITLE
Update deprovision template about removing a deployment config, not its resources

### DIFF
--- a/src/apb/dat/roles/deprovision/tasks/main.yml.j2
+++ b/src/apb/dat/roles/deprovision/tasks/main.yml.j2
@@ -26,25 +26,11 @@
 
 ##############################################################################
 ## Deprovision a deployment config
-## Unlike other resources, deprovisioning deployment configs also requires
-## cleanup of additional resources created.  This includes the pods and
-## replication controller
+## When removing a Deployment Config, OpenShift will automatically clean up
+## its associated resources like replication controllers and pods
 ##############################################################################
-## Have to scale down first or else orphaned pods will be left.
-#- openshift_v1_deployment_config:
-#    name: {{ apb_name }}
-#    namespace: '{% raw %}{{ namespace }}{% endraw %}'
-#    replicas: 0
-#    state: present
-
 ## Delete the deployment config.
 #- openshift_v1_deployment_config:
 #    name: {{ apb_name }}
-#    namespace: '{% raw %}{{ namespace }}{% endraw %}'
-#    state: absent
-
-## Destroy the orphaned replication controller.
-#- k8s_v1_replication_controller:
-#    name: {{ apb_name }}-1
 #    namespace: '{% raw %}{{ namespace }}{% endraw %}'
 #    state: absent


### PR DESCRIPTION
When removing a DeploymentConfig, OpenShift will take care to remove its associated resources like Replication Controllers and deployed pods, there's no need to manually clean these up.

