### PR TITLE
Addding insecure option for bootstrap,push,list,remove

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -27,6 +27,12 @@ def subcmd_list_parser(subcmd):
         dest='broker',
         help=u'Route to the Ansible Service Broker'
     )
+    subcmd.add_argument(
+        '-k',
+        action='store_false',
+        dest='verify',
+        help=u'Use insecure connection to Ansible Service Broker'
+    )
     return
 
 
@@ -147,6 +153,12 @@ def subcmd_push_parser(subcmd):
         dest='broker',
         help=u'Route to the Ansible Service Broker'
     )
+    subcmd.add_argument(
+        '-k',
+        action='store_false',
+        dest='verify',
+        help=u'Use insecure connection to Ansible Service Broker'
+    )
     return
 
 
@@ -171,6 +183,12 @@ def subcmd_remove_parser(subcmd):
         dest='id',
         help=u'ID of APB to remove'
     )
+    subcmd.add_argument(
+        '-k',
+        action='store_false',
+        dest='verify',
+        help=u'Use insecure connection to Ansible Service Broker'
+    )
     return
 
 
@@ -181,6 +199,12 @@ def subcmd_bootstrap_parser(subcmd):
         action='store',
         dest='broker',
         help=u'Route to the Ansible Service Broker'
+    )
+    subcmd.add_argument(
+        '-k',
+        action='store_false',
+        dest='verify',
+        help=u'Use insecure connection to Ansible Service Broker'
     )
     return
 

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -366,9 +366,10 @@ def broker_request(broker, service_route, method, **kwargs):
     if broker is None:
         raise Exception("Could not find route to ansible-service-broker. "
                         "Use --broker or log into the cluster using \"oc login\"")
+
     url = broker + service_route
     if url.find("http") < 0:
-        url = "http://" + url
+        url = "https://" + url
 
     try:
         response = requests.request(method, url, **kwargs)
@@ -380,7 +381,7 @@ def broker_request(broker, service_route, method, **kwargs):
 
 
 def cmdrun_list(**kwargs):
-    response = broker_request(kwargs["broker"], "/v2/catalog", "get")
+    response = broker_request(kwargs["broker"], "/v2/catalog", "get", verify=kwargs["verify"])
 
     if response.status_code != 200:
         print("Error: Attempt to list APBs in the broker returned status: %d" % response.status_code)
@@ -512,7 +513,7 @@ def cmdrun_push(**kwargs):
     spec = get_spec(project, 'string')
     blob = base64.b64encode(spec)
     data_spec = {'apbSpec': blob}
-    response = broker_request(kwargs["broker"], "/apb/spec", "post", data=data_spec)
+    response = broker_request(kwargs["broker"], "/apb/spec", "post", data=data_spec, verify=kwargs["verify"])
 
     if response.status_code != 200:
         print("Error: Attempt to add APB to the Broker returned status: %d" % response.status_code)
@@ -536,7 +537,7 @@ def cmdrun_remove(**kwargs):
         else:
             raise Exception("No APB ID specified.  Use --id or call apb remove from inside the project directory")
 
-    response = broker_request(kwargs["broker"], route, "delete")
+    response = broker_request(kwargs["broker"], route, "delete", kwargs["verifY"])
 
     if response.status_code != 204:
         print("Error: Attempt to remove an APB from Broker returned status: %d" % response.status_code)
@@ -547,7 +548,7 @@ def cmdrun_remove(**kwargs):
 
 
 def cmdrun_bootstrap(**kwargs):
-    response = broker_request(kwargs["broker"], "/v2/bootstrap", "post", data={})
+    response = broker_request(kwargs["broker"], "/v2/bootstrap", "post", data={}, verify=kwargs["verify"])
 
     if response.status_code != 200:
         print("Error: Attempt to bootstrap Broker returned status: %d" % response.status_code)


### PR DESCRIPTION
* Necessary due to merge of https for the broker route.

@dymurray The loading of the certificate and attempting to use that, will be in a subsequent PR. 
I think that this is block @johnkim76 so I want to get him something ASAP. 

Also, I think that the open shift is already defaulting to insecure, so I could see us amending this to do that as well?