### PR TITLE
simplify perms

### DIFF
--- a/src/apb/dat/Dockerfile.j2
+++ b/src/apb/dat/Dockerfile.j2
@@ -5,6 +5,5 @@ LABEL "com.redhat.apb.spec"=\
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN chown -R apb /opt/{ansible,apb} \
-    && chmod -R g=u /opt/{ansible,apb}
+RUN chmod -R g=u /opt/{ansible,apb}
 USER apb


### PR DESCRIPTION
we don't need a `chown` here, `chmod -R g=u` is sufficient since `apb` user is in root group.