### PR TITLE
Added unit testing setup and skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Install requirements and run the setup script (requires python)
 ```
 pip install -r src/requirements.txt && python setup.py install
 ```
+
+Optionally, if actively developing on the project, install the
+testing requirements:
+```
+pip install -r src/test-requirements.txt
+```
+
 Reactivate the `apb` virtualenv in other shell sessions using `source /tmp/apb/bin/activate` if needed.
 
 ###### Installing from source - Tito

--- a/src/test-requirements.txt
+++ b/src/test-requirements.txt
@@ -1,0 +1,2 @@
+nose
+mock

--- a/src/test/test_engine.py
+++ b/src/test/test_engine.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from apb import engine
+
+
+class EngineTests(TestCase):
+
+    def test_is_valid_spec_missing_keys(self):
+        # Test
+        result = engine.is_valid_spec({})
+
+        # Verify
+        self.assertFalse(result)


### PR DESCRIPTION
Nosetests will be installed as a testing requirement. Tests can be run by simply running "nosetests" in the root of the project.

I didn't see a section on actively developing on the abp project, so I added a quick note about the test requirements file in the "Installing from source" section.

I don't typically see a "src" directory in Python applications so I was a bit unsure of where to add the tests directory, but I threw it in there figuring that made the most sense.

I added a simple test to show the testing setup is valid, but that test will need to be flushed out.