### PR TITLE
Update display_type and display_group parameter docs to match UI changes.

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -132,8 +132,8 @@ parameters:
 * `type`: Data type of the parameters as specified by [json-schema](http://json-schema.org/) such as `string`, `number`, `int`, `boolean`, or `enum`.  Default input field type in the UI will be assigned if no `display_type` is assigned.
 * `required`: Whether or not the parameter is required for APB execution.  Required field in UI.
 * `default`: Default value assigned to the parameter.
-* `display_type`: Display type for the UI.  For example, you can override a string input as a `password` to hide it in the UI.  Accepted fields include `text`, `textarea`, `number`, `password`, `checkbox`, `select`, `radios`, `radios-inline`, `radiobuttons`.
-* `display_group`: will cause a parameter to display in groups with adjacent parameters with matching display_group fields.  In the above example, adding another field below with the `display_group: User Information` will visually group them together in the UI.
+* `display_type`: Display type for the UI.  For example, you can override a string input as a `password` to hide it in the UI.  Accepted fields include `text`, `textarea`, `password`, `checkbox`, `select`.
+* `display_group`: will cause a parameter to display in groups with adjacent parameters with matching `display_group` fields.  In the above example, adding another field below with `display_group: Group 1` will visually group them together in the UI under the heading "Group 1".
 
 #### Actions
 The following are the actions for an APB. At a minimum, an APB must implement the `provision` and `deprovision` actions.


### PR DESCRIPTION
The OpenShift UI now displays the `display_group` as the title for the group.  Further restricted `display_type`. 
https://github.com/openshift/origin-web-catalog/pull/399  Updating the docs to match.