### PR TITLE
added key= to sorted call for Python 2.7.13

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -575,7 +575,6 @@ def cmdrun_list(**kwargs):
                               basic_auth_username=kwargs.get("basic_auth_username"),
                               basic_auth_password=kwargs.get("basic_auth_password"))
 
-
     if response.status_code != 200:
         print("Error: Attempt to list APBs in the broker returned status: %d" % response.status_code)
         print("Unable to list APBs in Ansible Service Broker.")
@@ -658,7 +657,7 @@ def print_list(services):
 
     template = "{id:%d}{name:%d}{description:%d}" % (max_id + 2, max_name + 2, max_desc + 2)
     print(template.format(id="ID", name="NAME", description="DESCRIPTION"))
-    for service in sorted(services, lambda s:s['name']):
+    for service in sorted(services, key=lambda s:s['name']):
         print(template.format(**service))
 
 
@@ -836,6 +835,7 @@ def cmdrun_bootstrap(**kwargs):
 
     if not kwargs['no_relist']:
         relist_service_broker(kwargs)
+
 
 def cmdrun_test(**kwargs):
     project = kwargs['base_path']


### PR DESCRIPTION
`apb list` was failing on 2.7.13 because it needed the key= for sorted.