### PR TITLE
Fix pip install and error when dockers gid is in use in the container

### DIFF
--- a/Dockerfile-canary
+++ b/Dockerfile-canary
@@ -10,6 +10,7 @@ RUN source /opt/apb/bin/activate \
  && pip install -U pip setuptools
 RUN source /opt/apb/bin/activate \
  && cd ansible-playbook-bundle \
+ && pip install websocket-client==0.40.0 \
  && pip install -r src/requirements.txt \
  && python setup.py install
 RUN echo -ne "#!/bin/bash\nsource /opt/apb/bin/activate\napb \$@" > /usr/local/bin/apb-wrapper

--- a/apb-wrapper
+++ b/apb-wrapper
@@ -9,8 +9,8 @@ sudo groupadd apb -g $UID
 sudo usermod -a -G apb apb
 
 gid=$(stat -c '%g' /var/run/docker.sock)
-if [[ "0" == "$gid" ]]; then
-  group=root
+if GROUP=$(getent group -i $gid); then
+  group=echo $GROUP | awk -F ":" '{ print $1 }'
 else
   group=docker
   sudo groupadd $group -g $gid


### PR DESCRIPTION
python-docker will pull in websockets-client >= 0.40.0 during requirements but during setup kubernetes will complain that it needs <= 0.40.0, which is also fine for python-docker. So we install 0.40.0 first, docker uses that, and then kubernetes is happy.

We also had an issue where a users docker daemon was running with gid 50. This is in use by the ftp group on the container. There's no real problem with this, we just need to handle it in a way that doesn't produce errors.