### PR TITLE
Change broker_resource_url to fix apb relist.

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -367,7 +367,7 @@ def get_asb_route():
 
 
 def broker_resource_url(host, broker_name):
-    return "{}/apis/servicecatalog.k8s.io/v1alpha1/servicebrokers/{}".format(host, broker_name)
+    return "{}/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/{}".format(host, broker_name)
 
 
 def relist_service_broker(kwargs):


### PR DESCRIPTION
Fix for `apb relist` failure happening as of today.

Issue: https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/issues/144