### PR TITLE
fix issue with apb-wrapper

### DIFF
--- a/apb-wrapper
+++ b/apb-wrapper
@@ -10,7 +10,7 @@ sudo usermod -a -G apb apb
 
 gid=$(stat -c '%g' /var/run/docker.sock)
 if GROUP=$(getent group -i $gid); then
-  group=echo $GROUP | awk -F ":" '{ print $1 }'
+  group=$(echo $GROUP | awk -F ":" '{ print $1 }')
 else
   group=docker
   sudo groupadd $group -g $gid


### PR DESCRIPTION
This command was causing the error:
```
/usr/bin/apb-wrapper: line 13: ftp:x:50:: command not found
```

This change corrects that.