### PR TITLE
Add missing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ apb init my_apb --async=optional --bindable
 
 This gives us the following example apb.yaml
 ```
+version: 1.0
 name: my-apb
 description: "my-apb description"
 bindable: True


### PR DESCRIPTION
on the root `README` the `version: 1.0` is missing, which is now required w/ the latest ASB