### PR TITLE
Add the ability to create most of a serviceinstance template

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -16,6 +16,7 @@ AVAILABLE_COMMANDS = {
     'build': 'Build and package APB container',
     'push': 'Push local APB spec to an Ansible Service Broker',
     'remove': 'Remove APBs from the target Ansible Service Broker',
+    'serviceinstance': 'Create a ServiceInstance template based on apb.yaml',
     'bootstrap': 'Tell Ansible Service Broker to reload APBs from the container repository',
     'test': 'Test the APB'
 }
@@ -341,6 +342,10 @@ def subcmd_test_parser(subcmd):
         dest='tag',
         help=u'Tag of APB to build'
     )
+    return
+
+
+def subcmd_serviceinstance_parser(subcmd):
     return
 
 

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -864,25 +864,24 @@ def cmdrun_serviceinstance(**kwargs):
                     if param['required']:
                         # Save a required param name and set a defaultValue
                         params[param['name']] = defaultValue
-                except:
+                except Exception:
                     pass
         first_plan += 1
 
     plan_names = "%s)" % plan_names
-    serviceInstance = dict (
-        apiVersion = "servicecatalog.k8s.io/v1beta1",
-        kind = "ServiceInstance",
-        metadata = dict (
-            name = spec['name']
-        ),
-        spec = dict (
-            clusterServiceClassExternalName = "dh-" + spec['name'],
-            clusterServicePlanExternalName = plan_names,
-            parameters = params
-        )
-    )
+    serviceInstance = dict(apiVersion="servicecatalog.k8s.io/v1beta1",
+                           kind="ServiceInstance",
+                           metadata=dict(
+                               name=spec['name']
+                           ),
+                           spec=dict(
+                               clusterServiceClassExternalName="dh-" + spec['name'],
+                               clusterServicePlanExternalName=plan_names,
+                               parameters=params
+                           )
+                           )
 
-    with open(spec['name']+'.yaml', 'w') as outfile:
+    with open(spec['name'] + '.yaml', 'w') as outfile:
         yaml.dump(serviceInstance, outfile, default_flow_style=False)
 
 

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -11,6 +11,7 @@ import urllib3
 import docker
 import docker.errors
 import ruamel.yaml
+import yaml
 
 from ruamel.yaml import YAML
 from openshift import client as openshift_client, config as openshift_config
@@ -842,6 +843,47 @@ def cmdrun_bootstrap(**kwargs):
 
     if not kwargs['no_relist']:
         relist_service_broker(kwargs)
+
+
+def cmdrun_serviceinstance(**kwargs):
+    project = kwargs['base_path']
+    spec = get_spec(project)
+
+    defaultValue = "ansibleplaybookbundle"
+    params = {}
+    plan_names = "(Plans->"
+    first_plan = 0
+    for plan in spec['plans']:
+        plan_names = "%s|%s" % (plan_names, plan['name'])
+
+        # Only save the vars from the first plan
+        if first_plan == 0:
+            print("Only displaying vars from the '%s' plan." % plan['name'])
+            for param in plan['parameters']:
+                try:
+                    if param['required']:
+                        # Save a required param name and set a defaultValue
+                        params[param['name']] = defaultValue
+                except:
+                    pass
+        first_plan += 1
+
+    plan_names = "%s)" % plan_names
+    serviceInstance = dict (
+        apiVersion = "servicecatalog.k8s.io/v1beta1",
+        kind = "ServiceInstance",
+        metadata = dict (
+            name = spec['name']
+        ),
+        spec = dict (
+            clusterServiceClassExternalName = "dh-" + spec['name'],
+            clusterServicePlanExternalName = plan_names,
+            parameters = params
+        )
+    )
+
+    with open(spec['name']+'.yaml', 'w') as outfile:
+        yaml.dump(serviceInstance, outfile, default_flow_style=False)
 
 
 def cmdrun_test(**kwargs):


### PR DESCRIPTION
Most of the serviceinstance template can be created based off of
apb.yml.  Generate a nearly complete template and let the user
fill in the parameter values.