### PR TITLE
Bump APB Version

### DIFF
--- a/src/apb/dat/apb.yml.j2
+++ b/src/apb/dat/apb.yml.j2
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 name: {{ apb_dict['name'] }}
 description: {{ apb_dict['description'] }}
 bindable: {{ apb_dict['bindable'] }}


### PR DESCRIPTION
The asb-modules, specifically `asb_encode_binding`, creates a
secret instead of writing to a file. This breaks backwards compatibility
with older brokers. Therefore, we should bump the APB version string.

See [the
proposal](https://github.com/openshift/ansible-service-broker/blob/master/docs/proposals/prop-apb-gen-creds.md)
for more information.