### PR TITLE
APB Run Command

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -381,6 +381,7 @@ def subcmd_test_parser(subcmd):
     )
     return
 
+
 def subcmd_run_parser(subcmd):
     """ provision subcommand """
     subcmd.add_argument(
@@ -415,6 +416,7 @@ def subcmd_run_parser(subcmd):
         help=u'Name of Dockerfile to build with'
     )
     return
+
 
 def subcmd_relist_parser(subcmd):
     """ relist subcommand """

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -79,22 +79,7 @@ def subcmd_build_parser(subcmd):
         '--tag',
         action='store',
         dest='tag',
-        help=u'Tag of APB to build'
-    )
-
-    subcmd.add_argument(
-        '--registry',
-        action='store',
-        dest='registry',
-        help=u'Registry prefix of APB to prepend to tag'
-    )
-
-    subcmd.add_argument(
-        '--org',
-        '-o',
-        action='store',
-        dest='org',
-        help=u'Organization of APB to publish to'
+        help=u'Tag of APB to build (ie. mysql-apb or docker.io/username/mysql-apb)'
     )
 
     subcmd.add_argument(
@@ -384,7 +369,15 @@ def subcmd_test_parser(subcmd):
         '--tag',
         action='store',
         dest='tag',
-        help=u'Tag of APB to build'
+        help=u'Tag of APB to build (ie. mysql-apb or docker.io/username/mysql-apb)'
+    )
+
+    subcmd.add_argument(
+        '--dockerfile',
+        '-f',
+        action='store',
+        dest='dockerfile',
+        help=u'Name of Dockerfile to build with'
     )
     return
 
@@ -411,22 +404,7 @@ def subcmd_run_parser(subcmd):
         '--tag',
         action='store',
         dest='tag',
-        help=u'Tag of APB to build'
-    )
-
-    subcmd.add_argument(
-        '--registry',
-        action='store',
-        dest='registry',
-        help=u'Registry prefix of APB to prepend to tag'
-    )
-
-    subcmd.add_argument(
-        '--org',
-        '-o',
-        action='store',
-        dest='org',
-        help=u'Organization of APB to publish to'
+        help=u'Tag of APB to build (ie. mysql-apb or docker.io/username/mysql-apb)'
     )
 
     subcmd.add_argument(
@@ -436,7 +414,6 @@ def subcmd_run_parser(subcmd):
         dest='dockerfile',
         help=u'Name of Dockerfile to build with'
     )
-
     return
 
 def subcmd_relist_parser(subcmd):

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -17,7 +17,8 @@ AVAILABLE_COMMANDS = {
     'push': 'Push local APB spec to an Ansible Service Broker',
     'remove': 'Remove APBs from the target Ansible Service Broker',
     'bootstrap': 'Tell Ansible Service Broker to reload APBs from the container repository',
-    'test': 'Test the APB'
+    'test': 'Test the APB',
+    'run': 'Run APB'
 }
 
 
@@ -387,6 +388,64 @@ def subcmd_test_parser(subcmd):
     )
     return
 
+def subcmd_run_parser(subcmd):
+    """ provision subcommand """
+    subcmd.add_argument(
+        '--namespace',
+        action='store',
+        dest='namespace',
+        required=True,
+        help=u'Namespace where the APB should be run'
+    )
+
+    subcmd.add_argument(
+        '--action',
+        action='store',
+        dest='action',
+        required=False,
+        help=u'The action to perform when running the APB',
+        default='provision'
+    )
+
+    subcmd.add_argument(
+        '--tag',
+        action='store',
+        dest='tag',
+        help=u'Tag of APB to build'
+    )
+
+    subcmd.add_argument(
+        '--registry',
+        action='store',
+        dest='registry',
+        help=u'Registry prefix of APB to prepend to tag'
+    )
+
+    subcmd.add_argument(
+        '--org',
+        '-o',
+        action='store',
+        dest='org',
+        help=u'Organization of APB to publish to'
+    )
+
+    subcmd.add_argument(
+        '--dockerfile',
+        '-f',
+        action='store',
+        dest='dockerfile',
+        help=u'Name of Dockerfile to build with'
+    )
+
+#    subcmd.add_argument(
+#        '--editor',
+#        action='store_true',
+#        dest='editor',
+#        required=False,
+#        help=u'Use $EDITOR for parameter prompt',
+#        default=False
+#    )
+    return
 
 def subcmd_relist_parser(subcmd):
     """ relist subcommand """

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -391,11 +391,11 @@ def subcmd_test_parser(subcmd):
 def subcmd_run_parser(subcmd):
     """ provision subcommand """
     subcmd.add_argument(
-        '--namespace',
+        '--project',
         action='store',
-        dest='namespace',
+        dest='project',
         required=True,
-        help=u'Namespace where the APB should be run'
+        help=u'Project where the APB should be run'
     )
 
     subcmd.add_argument(
@@ -437,14 +437,6 @@ def subcmd_run_parser(subcmd):
         help=u'Name of Dockerfile to build with'
     )
 
-#    subcmd.add_argument(
-#        '--editor',
-#        action='store_true',
-#        dest='editor',
-#        required=False,
-#        help=u'Use $EDITOR for parameter prompt',
-#        default=False
-#    )
     return
 
 def subcmd_relist_parser(subcmd):

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -568,7 +568,15 @@ def create_pod(image, name, namespace, command, service_account):
                         'image': image,
                         'imagePullPolicy': 'IfNotPresent',
                         'name': name,
-                        'command': command
+                        'command': command,
+                        'env': [
+                            {'name': 'POD_NAME',
+                             'valueFrom': {'fieldRef': {'fieldPath': 'metadata.name'}}
+                            },
+                            {'name': 'POD_NAMESPACE',
+                             'valueFrom': {'fieldRef': {'fieldPath': 'metadata.namespace'}}
+                            }
+                        ],
                     }],
                     'restartPolicy': 'Never',
                     'serviceAccountName': service_account,


### PR DESCRIPTION
This PR implements an `apb run` command that works even as a developer to run an APB in a specified namespace. There are some limitations:

- Since apb build, prepare, etc. all work on the current apb project...this does that too. So I have to be "in" the 'hello-world-apb' project in order to `apb-run` that APB.
- APBs that try to create anything above the permissions of a `$namespace:admin` will fail...hard.
- APBs that use `asb_encode_binding` will fail because we aren't passing the POD_NAME and POD_NAMESPACE to the pod we create...I can add this. But I think the right thing from an APB developer perspective is to specifically create a secret when not using the ansible broker. However, I'm not sure how we would communicate that to APBs.