### PR TITLE
Locate the apb route, but avoid the etcd route

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -405,7 +405,7 @@ def get_asb_route():
         oapi = openshift_client.OapiApi()
         route_list = oapi.list_namespaced_route('ansible-service-broker')
         for route in route_list.items:
-            if 'asb' in route.metadata.name and not 'etcd' in route.metadata.name:
+            if 'asb' in route.metadata.name and 'etcd' not in route.metadata.name:
                 asb_route = route.spec.host
     except Exception:
         asb_route = None

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -405,7 +405,7 @@ def get_asb_route():
         oapi = openshift_client.OapiApi()
         route_list = oapi.list_namespaced_route('ansible-service-broker')
         for route in route_list.items:
-            if route.metadata.name.find('asb-') >= 0:
+            if 'asb' in route.metadata.name and not 'etcd' in route.metadata.name:
                 asb_route = route.spec.host
     except Exception:
         asb_route = None


### PR DESCRIPTION
When running locally, both the asb and asb-ectd route are present. This causes ```apb list``` to use the etcd route and fail to list apbs.

fixes #184 
  