### PR TITLE
Generic tool improvements

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -265,6 +265,13 @@ def subcmd_push_parser(subcmd):
         help=u'Name of the ServiceBroker k8s resource',
         default=u'ansible-service-broker'
     )
+    subcmd.add_argument(
+        '--push-to-broker',
+        action='store_true',
+        dest='broker_push',
+        help=u'Use Broker development endpoint at /v2/apb/spec',
+        default=False
+    )
     return
 
 

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -214,14 +214,6 @@ def subcmd_push_parser(subcmd):
         default=u'default'
     )
     subcmd.add_argument(
-        '--openshift',
-        '-o,',
-        action='store_true',
-        dest='openshift',
-        help=u'Use internal OpenShift registry',
-        default=False
-    )
-    subcmd.add_argument(
         '--dockerfile',
         '-f',
         action='store',

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -269,7 +269,7 @@ def subcmd_push_parser(subcmd):
         '--push-to-broker',
         action='store_true',
         dest='broker_push',
-        help=u'Use Broker development endpoint at /v2/apb/spec',
+        help=u'Use Broker development endpoint at /v2/apb/',
         default=False
     )
     return

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -215,6 +215,12 @@ def subcmd_push_parser(subcmd):
         default=u'default'
     )
     subcmd.add_argument(
+        '--registry-route',
+        action='store',
+        dest='reg_route',
+        help=u'Route of internal OpenShift registry'
+    )
+    subcmd.add_argument(
         '--dockerfile',
         '-f',
         action='store',

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -11,6 +11,7 @@ AVAILABLE_COMMANDS = {
     'help': 'Display this help message',
     'relist': 'Relist the APBs available within the Service Catalog',
     'list': 'List APBs from the target Ansible Service Broker',
+    'setup': 'Initialize OpenShift with APB development environment',
     'init': 'Initialize the directory for APB development',
     'prepare': 'Prepare an ansible-container project for APB packaging',
     'build': 'Build and package APB container',
@@ -422,6 +423,10 @@ def subcmd_run_parser(subcmd):
         dest='dockerfile',
         help=u'Name of Dockerfile to build with'
     )
+    return
+
+
+def subcmd_setup_parser(subcmd):
     return
 
 

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -20,7 +20,6 @@ from openshift.helper.openshift import OpenShiftObjectHelper
 from jinja2 import Environment, FileSystemLoader
 from kubernetes import client as kubernetes_client, config as kubernetes_config
 from kubernetes.client.rest import ApiException
-from openshift.client.models import V1ClusterRoleBinding
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 # Handle input in 2.x/3.x
@@ -891,7 +890,7 @@ def build_apb(project, dockerfile=None, tag=None):
 
 def cmdrun_setup(**kwargs):
     try:
-        docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock', version='auto')
+        docker.DockerClient(base_url='unix://var/run/docker.sock', version='auto')
     except Exception as e:
         print("Error! Failed to connect to Docker client. Please ensure it is running. Exception: %s" % e)
         exit(1)
@@ -934,14 +933,17 @@ def cmdrun_setup(**kwargs):
             broker_installed = True
         elif "service-catalog" in name:
             svccat_installed = True
-    if broker_installed == False:
+    if broker_installed is False:
         print("Error! Could not find OpenShift Ansible Broker namespace. Please ensure that the broker is\
                 installed and that the current logged in user has access.")
         print("Current user is: %s" % "foo")
         exit(1)
-    if svccat_installed == False:
+    if svccat_installed is False:
         print("Error! Could not find OpenShift Service Catalog namespace. Please ensure that the Service\
                 Catalog is installed and that the current logged in user has access.")
+        print("Current user is: %s" % "foo")
+    if proj_default_access is False:
+        print("Error! Could not find the Default namespace. Please ensure that the current logged in user has access.")
         print("Current user is: %s" % "foo")
 
 

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1069,11 +1069,16 @@ def cmdrun_push(**kwargs):
 
     namespace = kwargs['reg_namespace']
     service = kwargs['reg_svc_name']
-    # Assume we are using internal registry, no need to push to broker
-    registry = get_registry_service_ip(namespace, service)
-    if registry is None:
-        print("Failed to find registry service IP address.")
-        raise Exception("Unable to get registry IP from namespace %s" % namespace)
+    registry_route = kwargs['reg_route']
+
+    if registry_route:
+        registry = registry_route
+    else:
+        registry = get_registry_service_ip(namespace, service)
+        if registry is None:
+            print("Failed to find registry service IP address.")
+            raise Exception("Unable to get registry IP from namespace %s" % namespace)
+
     tag = registry + "/" + kwargs['namespace'] + "/" + dict_spec['name']
     print("Building image with the tag: " + tag)
     try:

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1053,7 +1053,7 @@ def cmdrun_push(**kwargs):
     if broker is None:
         broker = get_asb_route()
     print(spec)
-    if kwargs['broker_dev']:
+    if kwargs['broker_push']:
         response = broker_request(kwargs["broker"], "/v2/apb", "post", data=data_spec,
                                   verify=kwargs["verify"],
                                   basic_auth_username=kwargs.get("basic_auth_username"),

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -936,15 +936,12 @@ def cmdrun_setup(**kwargs):
     if broker_installed is False:
         print("Error! Could not find OpenShift Ansible Broker namespace. Please ensure that the broker is\
                 installed and that the current logged in user has access.")
-        print("Current user is: %s" % "foo")
         exit(1)
     if svccat_installed is False:
         print("Error! Could not find OpenShift Service Catalog namespace. Please ensure that the Service\
                 Catalog is installed and that the current logged in user has access.")
-        print("Current user is: %s" % "foo")
     if proj_default_access is False:
         print("Error! Could not find the Default namespace. Please ensure that the current logged in user has access.")
-        print("Current user is: %s" % "foo")
 
 
 def cmdrun_init(**kwargs):

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1104,9 +1104,9 @@ def cmdrun_push(**kwargs):
 
 def cmdrun_remove(**kwargs):
     if kwargs["all"]:
-        route = "/v2/apb"
+        route = "/v2/apb/"
     elif kwargs["id"] is not None:
-        route = "/v2/apb" + kwargs["id"]
+        route = "/v2/apb/" + kwargs["id"]
     else:
         raise Exception("No APB ID specified.  Use --id.")
 


### PR DESCRIPTION
* Added `apb setup`
  * Creates user `apb-developer` with `cluster-admin` rights
* Added sanity checks for --broker suffix so that `<route>/ansible-service-broker` isn't required and just `<route>` will work.
*  make `apb push -o` the default `apb push` and old `apb push` functionality is `apb push --push-to-broker`.
  
  