### PR TITLE
Add support for minishift to apb container

### DIFF
--- a/apb-wrapper
+++ b/apb-wrapper
@@ -8,7 +8,12 @@ echo "apb:x:$UID:$UID:apb:/home/apb:/bin/bash" >> /etc/passwd
 sudo groupadd apb -g $UID
 sudo usermod -a -G apb apb
 
-gid=$(stat -c '%g' /var/run/docker.sock)
+if ! [[ "${MINISHIFT_REGISTRY}" == "" ]]; then
+  gid=$(stat -c '%g' ${DOCKER_CERT_PATH}/ca.pem)
+else
+  gid=$(stat -c '%g' /var/run/docker.sock)
+fi
+
 if GROUP=$(getent group -i $gid); then
   group=$(echo $GROUP | awk -F ":" '{ print $1 }')
 else

--- a/docs/apb_cli.md
+++ b/docs/apb_cli.md
@@ -37,29 +37,29 @@ care of the details so they should be easy to deploy.
 
 [Docker](https://www.docker.com/) must be correctly installed and running on the system.
 
+NOTE: If you are working with a minishift cluster and the [ansible-service-broker addon](https://github.com/minishift/minishift-addons/tree/master/add-ons/ansible-service-broker),
+you must first configure your shell to use the minishift Docker daemon. This can
+be done with `eval $(minishift docker-env)`. For more info, see [minishift's documentation for working with its docker registry](https://docs.openshift.org/latest/minishift/using/docker-daemon.html).
+
 #### Running from a container
 
 Pull the container:
 ```bash
 docker pull docker.io/ansibleplaybookbundle/apb-tools
 ```
-
-Create an alias in your `.bashrc` or somewhere else sane for your shell:
-```bash
-alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools'
-```
-
-You should be able to start working by running `apb init my_apb`. The first run may take awhile if you did not pull the image.
-
-If you would prefer to use atomic rather than an alias this is also possible:
-```bash
-atomic run docker.io/ansibleplaybookbundle/apb-tools init my_apb
-```
-
 There are three tags to choose from:
 - **latest**: more stable, less frequent releases
 - **nightly**: following upstream commits, installed from RPM
 - **canary**: following upstream commits, installed from source build
+
+Copy the [apb-docker-run.sh](../scripts/apb-docker-run.sh) script into your `PATH` and
+make sure it's executable:
+
+```
+cp $APB_CHECKOUT/scripts/apb-docker-run.sh $YOUR_PATH_DIR/apb && chmod +x $YOUR_PATH_DIR/apb
+```
+
+You should be able to start working by running `apb init my_apb`. The first run may take awhile if you did not pull the image.
 
 #### RPM Installation
 
@@ -173,11 +173,6 @@ be sufficient.
 
 #### Local Registry
 In order to use the internal OpenShift Docker Registry to source APBs, you must have configured the Ansible Service Broker to use the `local_openshift` type registry adapter. Please see the [config](https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#local-openshift-registry) section for more information.
-
-NOTE: If you are working with a minishift cluster and the [ansible-service-broker addon](https://github.com/minishift/minishift-addons/tree/master/add-ons/ansible-service-broker),
-you must first configure your shell to use the minishift Docker daemon. This can
-be done with `eval $(minishift docker-env)`. For more info, see [minishift's documentation for working with its docker registry](https://docs.openshift.org/latest/minishift/using/docker-daemon.html).
-
 
 ```bash
 apb init my-new-apb

--- a/scripts/apb-docker-run.sh
+++ b/scripts/apb-docker-run.sh
@@ -1,0 +1,42 @@
+# Script for running apb with a container.
+# Recommended to copy this to somewhere in your PATH as "apb"
+APB_IMAGE=${APB_IMAGE:-docker.io/ansibleplaybookbundle/apb-tools:canary}
+echo "Running APB image: ${APB_IMAGE}"
+
+if ! [[ -z "${DOCKER_CERT_PATH}" ]] && [[ ${DOCKER_CERT_PATH} = *"minishift"* ]]; then
+  IS_MINISHIFT=true
+  echo "Targetting minishift host: ${DOCKER_HOST}"
+fi
+
+if [[ $IS_MINISHIFT = true ]]; then
+  # If targetting minishift, there are some unique issues with using the apb
+  # container. Need to capture the minishift docker-env vars, unset them for the
+  # purposes of this command, and pass them through to the docker container along
+  # with mounting the minishift docker certs.
+  # The minishift docker-env must be unset so the apb container is run by the *host*
+  # daemon instead of the minishift daemon. However, It will still be configured
+  # to operate on the minishift registry. This is required, as the volume mounts
+  # must be mounted into the apb container from the host system.
+  # If the minishift daemon is used, they will be empty mounts.
+  MINISHIFT_DOCKER_CERT_SRC="${DOCKER_CERT_PATH}"
+  MINISHIFT_DOCKER_CERT_DEST="/var/run/minishift-certs"
+  MINISHIFT_DOCKER_HOST="${DOCKER_HOST}"
+
+  unset DOCKER_TLS_VERIFY
+  unset DOCKER_HOST
+  unset DOCKER_CERT_PATH
+
+  docker run --rm --privileged \
+    -v $PWD:/mnt -v $HOME/.kube:/.kube \
+    -v $MINISHIFT_DOCKER_CERT_SRC:$MINISHIFT_DOCKER_CERT_DEST \
+    -e DOCKER_TLS_VERIFY="1" \
+    -e DOCKER_HOST="${MINISHIFT_DOCKER_HOST}" \
+    -e DOCKER_CERT_PATH="${MINISHIFT_DOCKER_CERT_DEST}" \
+    -e MINISHIFT_REGISTRY=$(minishift openshift registry) \
+    -u $UID $APB_IMAGE "$@"
+else
+  docker run --rm --privileged \
+    -v $PWD:/mnt -v $HOME/.kube:/.kube \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -u $UID $APB_IMAGE "$@"
+fi

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1350,4 +1350,5 @@ def is_minishift():
 
 def get_minishift_registry():
     cmd = "minishift openshift registry"
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).rstrip()
+    return os.environ.get('MINISHIFT_REGISTRY') or \
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).rstrip()


### PR DESCRIPTION
This should be pretty much done, but I did have one question about the docs (see the TODO). Does that atomic command actually work without any of the environment config? It's not going to work for minishift, I'm wondering if this script makes that comment obsolete?

Also wondering if the best advice for this is to copy it into your path. There's plenty of ways to get it into your system as a command; I would rather not encourage folks to curl random scripts off the internet.