### PR TITLE
Use the host network namespace with containerized apb-tool

### DIFF
--- a/docs/apb_cli.md
+++ b/docs/apb_cli.md
@@ -47,6 +47,12 @@ Pull the container:
 ```bash
 docker pull docker.io/ansibleplaybookbundle/apb-tools
 ```
+
+Create an alias in your `.bashrc` or somewhere else sane for your shell:
+```bash
+alias apb='docker run --rm --privileged --net=host -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools'
+```
+
 There are three tags to choose from:
 - **latest**: more stable, less frequent releases
 - **nightly**: following upstream commits, installed from RPM


### PR DESCRIPTION
Running without ```--net=host``` can cause the containerized apb-tool to not find the cluster endpoints.
```
2018-01-26 12:50:03,797 WARNING Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x337fb90>: Failed to establish a new connection: [Errno 111] Connection refused',)': /oapi/v1/namespaces/ansible-service-broker/routes
2018-01-26 12:50:03,797 WARNING Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x337f9d0>: Failed to establish a new connection: [Errno 111] Connection refused',)': /oapi/v1/namespaces/ansible-service-broker/routes
2018-01-26 12:50:03,798 WARNING Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x337fe90>: Failed to establish a new connection: [Errno 111] Connection refused',)': /oapi/v1/namespaces/ansible-service-broker/routes
Exception occurred! Could not find route to ansible-service-broker. Use --broker or log into the cluster using "oc login"
```
fixes: #181 