### PR TITLE
Include labels in ServiceInstance definition

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1205,7 +1205,7 @@ def cmdrun_serviceinstance(**kwargs):
                            kind="ServiceInstance",
                            metadata=dict(
                                name=spec['name'],
-                               labels=spec['labels']
+                               labels=dict(spec['labels'])
                            ),
                            spec=dict(
                                clusterServiceClassExternalName="dh-" + spec['name'],

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1204,7 +1204,8 @@ def cmdrun_serviceinstance(**kwargs):
     serviceInstance = dict(apiVersion="servicecatalog.k8s.io/v1beta1",
                            kind="ServiceInstance",
                            metadata=dict(
-                               name=spec['name']
+                               name=spec['name'],
+                               labels=spec['labels']
                            ),
                            spec=dict(
                                clusterServiceClassExternalName="dh-" + spec['name'],


### PR DESCRIPTION
Hi folks, on the Red Hat Mobile team we're building out a number of APBs for provisioning mobile services on OpenShift.

In our case, we need each ServiceInstance to have some labels. Right now we're doing some janky stuff in our APBs to retrieve the ServiceInstance name and then add labels after it's been created.

The result of this PR is that we can define `labels` in `apb.yml` and the `apb serviceinstance` command will include those labels in the ServiceInstance yaml file that gets created. However I'm not sure if this change will also propagate into the actual provisioning of the ServiceInstance when the APB is run. 

I'd love if someone could point me in the right direction so we can implement this behaviour