### PR TITLE
Bug 1523252 - Prepend broker route with https if no schema supplied

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -755,6 +755,9 @@ def broker_request(broker, service_route, method, **kwargs):
             broker = broker + '/'
         broker = broker + 'ansible-service-broker'
 
+    if not broker.startswith('http'):
+        broker = 'https://' + broker
+
     url = broker + service_route
     print("Contacting the ansible-service-broker at: %s" % url)
 


### PR DESCRIPTION
If the user specifies the `--broker` flag and does not include a schema we should automatically include a schema so we don't see ugly errors.