### PR TITLE
Bug 1540487 - Fix apb remove URL suffix

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1137,7 +1137,7 @@ def cmdrun_push(**kwargs):
 
 def cmdrun_remove(**kwargs):
     if kwargs["all"]:
-        route = "/v2/apb/"
+        route = "/v2/apb"
     elif kwargs["id"] is not None:
         route = "/v2/apb/" + kwargs["id"]
     else:


### PR DESCRIPTION
`apb remove --all` was failing because of the added slash.