### PR TITLE
Remove alias from docs

### DIFF
--- a/docs/apb_cli.md
+++ b/docs/apb_cli.md
@@ -48,11 +48,6 @@ Pull the container:
 docker pull docker.io/ansibleplaybookbundle/apb-tools
 ```
 
-Create an alias in your `.bashrc` or somewhere else sane for your shell:
-```bash
-alias apb='docker run --rm --privileged --net=host -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools'
-```
-
 There are three tags to choose from:
 - **latest**: more stable, less frequent releases
 - **nightly**: following upstream commits, installed from RPM


### PR DESCRIPTION
Should prefer the script over the alias. I'm not sure how this snuck in.