### PR TITLE
Bug 1536687 - Prevent script from running as root

### DIFF
--- a/scripts/apb-docker-run.sh
+++ b/scripts/apb-docker-run.sh
@@ -1,6 +1,12 @@
 # Script for running apb with a container.
 # Recommended to copy this to somewhere in your PATH as "apb"
 APB_IMAGE=${APB_IMAGE:-docker.io/ansibleplaybookbundle/apb-tools:canary}
+
+if [[ $(id -u) = 0 ]]; then
+  echo "apb should not be run as root!"
+  exit 1
+fi
+
 echo "Running APB image: ${APB_IMAGE}"
 
 if ! [[ -z "${DOCKER_CERT_PATH}" ]] && [[ ${DOCKER_CERT_PATH} = *"minishift"* ]]; then


### PR DESCRIPTION
* The apb container script will blow up if the user runs as root, and
its entirely unecessary, so we should prefer least privilege.