### PR TITLE
Openshift doc changed, and routes are now on the network section

### DIFF
--- a/src/apb/dat/roles/provision/tasks/main.yml.j2
+++ b/src/apb/dat/roles/provision/tasks/main.yml.j2
@@ -61,7 +61,7 @@
 ## An OpenShift Origin route exposes a service at a host name, so that external
 ## clients can reach it by name. Each route consists of a name, a service
 ## selector, and an optional security configuration.
-## https://docs.openshift.org/latest/architecture/core_concepts/routes.html
+## https://docs.openshift.org/latest/architecture/networking/routes.html
 ##############################################################################
 #- name: create {{ apb_dict['app_name'] }} route
 #  openshift_v1_route:


### PR DESCRIPTION
Provided link in the sample is not working; 

Routes are being discussed in the network section 