### PR TITLE
Bug 1550017 - Add ability to remove locally pushed APBs

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -286,6 +286,13 @@ def subcmd_remove_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
+        '--local', '-l',
+        action='store_true',
+        dest='local',
+        help=u'Remove image from internal OpenShift registry',
+        default=False
+    )
+    subcmd.add_argument(
         '--all',
         action='store_true',
         dest='all',

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -1185,11 +1185,15 @@ def cmdrun_remove(**kwargs):
         tag = registry + "/" + kwargs['namespace'] + "/" + spec['name']
         print("Image: [%s]" % tag)
         delete_old_images(tag)
-        bootstrap(kwargs["broker"], kwargs.get("basic_auth_username"), kwargs.get("basic_auth_password"), kwargs["verify"])
+        bootstrap(
+            kwargs["broker"],
+            kwargs.get("basic_auth_username"),
+            kwargs.get("basic_auth_password"),
+            kwargs["verify"]
+        )
         exit()
     else:
         raise Exception("No flag specified.  Use --id or --local.")
-
 
     response = broker_request(kwargs["broker"], route, "delete",
                               verify=kwargs["verify"],

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -935,6 +935,7 @@ def delete_old_images(image_name):
         for image in image_list['items']:
             image_fqn, image_sha = image['dockerImageReference'].split("@")
             if image_name in image_fqn:
+                print("Found image: %s" % image_fqn)
                 if registry not in image_fqn:
                     # This warning will only get displayed if a user has used --registry-route
                     # This is because the route name gets collapsed into the service hostname
@@ -942,6 +943,7 @@ def delete_old_images(image_name):
                     print("Warning: Tagged image registry prefix doesn't match. Deleting anyway. Given: %s; Found: %s"
                           % (registry, image_fqn.split('/')[0]))
                 oapi.delete_image(name=image_sha, body={})
+                print("Successfully deleted %s" % image_sha)
 
     except Exception as e:
         print("Exception deleting old images: %s" % e)
@@ -1170,8 +1172,24 @@ def cmdrun_remove(**kwargs):
         route = "/v2/apb"
     elif kwargs["id"] is not None:
         route = "/v2/apb/" + kwargs["id"]
+    elif kwargs["local"] is True:
+        print("Attempting to delete associated registry image.")
+        project = kwargs['base_path']
+        spec = get_spec(project, 'dict')
+        kwargs['reg_namespace'] = "default"
+        kwargs['reg_svc_name'] = "docker-registry"
+        kwargs['reg_route'] = None
+        kwargs['namespace'] = "openshift"
+
+        registry = get_registry(kwargs)
+        tag = registry + "/" + kwargs['namespace'] + "/" + spec['name']
+        print("Image: [%s]" % tag)
+        delete_old_images(tag)
+        bootstrap(kwargs["broker"], kwargs.get("basic_auth_username"), kwargs.get("basic_auth_password"), kwargs["verify"])
+        exit()
     else:
-        raise Exception("No APB ID specified.  Use --id.")
+        raise Exception("No flag specified.  Use --id or --local.")
+
 
     response = broker_request(kwargs["broker"], route, "delete",
                               verify=kwargs["verify"],


### PR DESCRIPTION
* We have a locally pushed APB
```
[dymurray@dymurray mediawiki-apb]$ apb list
...
                       
a946a139a9308a59bf642ac52b4ba317  dh-wordpress-ha-apb          High Availability Wordpress APB                                                                                                                     
                       
c23ec213bb8dea1577230c5ce005b9c2  localregistry-mediawiki-apb  Mediawiki apb implementation      
```
```
[dymurray@dymurray mediawiki-apb]$ oc get images | grep apb
sha256:7f6da2dffe0da82a018a00e2e37698e6dcfc3864a1deae4421f305762f42e657   172.30.1.1:5000/openshift/mediawiki-apb@sha256:7f6da2dffe0da82a018a00e2e37698e6dcfc3864a1deae4421f305762f42e657
```

* now we do `apb remove --local` to remove internally pushed image

```
[dymurray@dymurray mediawiki-apb]$ apb remove --local
Attempting to delete associated registry image.
Image: [172.30.1.1:5000/openshift/mediawiki-apb]
Found image: 172.30.1.1:5000/openshift/mediawiki-apb
Successfully deleted sha256:7f6da2dffe0da82a018a00e2e37698e6dcfc3864a1deae4421f305762f42e657
Contacting the ansible-service-broker at: https://asb-1338-ansible-service-broker.192.168.42.3.nip.io/ansible-service-broker/v2/bootstrap
Successfully bootstrapped Ansible Service Broker
```