### PR TITLE
Bug 1573714 - PoC token arg support

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -570,6 +570,14 @@ def main():
         default=os.getcwd()
     )
 
+    parser.add_argument(
+        '--token',
+        action='store',
+        dest='auth_token',
+        help=u'Specify OpenShift auth token to be used',
+        default=None
+    )
+
     subparsers = parser.add_subparsers(title='subcommand', dest='subcommand')
     subparsers.required = True
 


### PR DESCRIPTION
Hi, we want to supply authentication token to `apb` as a parameter. It works
with any auth configuration unlike basic auth. Also sometimes kubeconfig
might be in a non-standard location.

I haven't tested the code, just wanted to hear whether this kind of change
would be accepted before spending more time on it.

P.S. maybe we also need a parameter `--kube-config`