### PR TITLE
Update Makefile template

### DIFF
--- a/src/apb/dat/Makefile.j2
+++ b/src/apb/dat/Makefile.j2
@@ -8,7 +8,7 @@ build_and_push: apb_build docker_push apb_push
 
 .PHONY: apb_build
 apb_build:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest prepare
+	apb prepare
 	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
 
 .PHONY: docker_push
@@ -17,5 +17,5 @@ docker_push:
 
 .PHONY: apb_push
 apb_push:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest push
+	apb push
 


### PR DESCRIPTION

Don't force the use of the containerised apb tools in Makefile commands, instead apb should be installed locally using one of the recommended approaches https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool