### PR TITLE
Added fix if using pip newer than 9.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 install_reqs = parse_requirements('src/requirements.txt', session=False)
 reqs = [str(ir.req) for ir in install_reqs]


### PR DESCRIPTION
Ran into below issue when trying to install from source on Mac.

```
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/4n/bn1h2yx55ts7_yz9yf3ybdc80000gn/T/pip-req-build-jG8NYg/setup.py", line 2, in <module>
        from pip.req import parse_requirements
    ImportError: No module named req
```

Added workaround, seeing succes now.

$ pip --version
pip 10.0.1 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
