### PR TITLE
Bug 1572452 - Deprecate --secure flag for SSL verification

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -36,13 +36,6 @@ def subcmd_list_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
-    )
-    subcmd.add_argument(
         '--verbose',
         '-v',
         action='store_true',
@@ -224,13 +217,6 @@ def subcmd_push_parser(subcmd):
         default=u'Dockerfile'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
-    )
-    subcmd.add_argument(
         '--username',
         '-u',
         action='store',
@@ -299,13 +285,6 @@ def subcmd_remove_parser(subcmd):
         help=u'ID of APB to remove'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
-    )
-    subcmd.add_argument(
         '--username',
         '-u',
         action='store',
@@ -345,13 +324,6 @@ def subcmd_bootstrap_parser(subcmd):
         action='store',
         dest='broker',
         help=u'Route to the Ansible Service Broker'
-    )
-    subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
     )
     subcmd.add_argument(
         '--no-relist',
@@ -503,13 +475,6 @@ def subcmd_relist_parser(subcmd):
         default=u'ansible-service-broker'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
-    )
-    subcmd.add_argument(
         '--username',
         '-u',
         action='store',
@@ -530,13 +495,6 @@ def subcmd_relist_parser(subcmd):
 
 def subcmd_refresh_parser(subcmd):
     """ version subcommand """
-    subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
-        default=False
-    )
     subcmd.add_argument(
         '--username',
         '-u',

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -438,7 +438,7 @@ def relist_service_broker(kwargs):
         response = requests.request(
             "get",
             broker_resource_url(cluster_host, broker_name),
-            verify=kwargs['verify'], headers=headers)
+            verify=False, headers=headers)
 
         if response.status_code != 200:
             errMsg = "Received non-200 status code while retrieving broker: {}\n".format(broker_name) + \
@@ -464,7 +464,7 @@ def relist_service_broker(kwargs):
             "patch",
             broker_resource_url(cluster_host, broker_name),
             json={'spec': {'relistRequests': inc_relist_requests}},
-            verify=kwargs['verify'], headers=headers)
+            verify=False, headers=headers)
 
         if response.status_code != 200:
             errMsg = "Received non-200 status code while patching relistRequests of broker: {}\n".format(
@@ -762,7 +762,7 @@ def broker_request(broker, service_route, method, **kwargs):
         else:
             token = openshift_client.Configuration().get_api_key_with_prefix('authorization')
             headers = {'Authorization': token}
-        response = requests.request(method, url, verify=kwargs["verify"],
+        response = requests.request(method, url, verify=False,
                                     headers=headers, data=kwargs.get("data"))
     except Exception as e:
         print("ERROR: Failed broker request (%s) %s" % (method, url))
@@ -773,7 +773,7 @@ def broker_request(broker, service_route, method, **kwargs):
 
 def cmdrun_list(**kwargs):
     response = broker_request(kwargs['broker'], "/v2/catalog", "get",
-                              verify=kwargs["verify"],
+                              verify=False,
                               basic_auth_username=kwargs.get("basic_auth_username"),
                               basic_auth_password=kwargs.get("basic_auth_password"),
                               auth_token=kwargs.get("auth_token"))
@@ -1142,7 +1142,7 @@ def cmdrun_push(**kwargs):
     print(spec)
     if kwargs['broker_push']:
         response = broker_request(broker, "/v2/apb", "post", data=data_spec,
-                                  verify=kwargs["verify"],
+                                  verify=False,
                                   basic_auth_username=kwargs.get("basic_auth_username"),
                                   basic_auth_password=kwargs.get("basic_auth_password"),
                                   auth_token=kwargs.get("auth_token"))
@@ -1165,7 +1165,7 @@ def cmdrun_push(**kwargs):
         kwargs.get("basic_auth_username"),
         kwargs.get("basic_auth_password"),
         kwargs.get("auth_token"),
-        kwargs["verify"]
+        False
     )
 
     if not kwargs['no_relist']:
@@ -1209,14 +1209,14 @@ def cmdrun_remove(**kwargs):
             kwargs.get("basic_auth_username"),
             kwargs.get("basic_auth_password"),
             kwargs.get("auth_token"),
-            kwargs["verify"]
+            False
         )
         exit()
     else:
         raise Exception("No flag specified.  Use --id or --local.")
 
     response = broker_request(kwargs["broker"], route, "delete",
-                              verify=kwargs["verify"],
+                              verify=False,
                               basic_auth_username=kwargs.get("basic_auth_username"),
                               basic_auth_password=kwargs.get("basic_auth_password"),
                               auth_token=kwargs.get("auth_token"))
@@ -1225,7 +1225,7 @@ def cmdrun_remove(**kwargs):
         print("Received a 404 trying to remove APB with id: %s" % kwargs["id"])
         print("Attempting to contact 3.7 endpoint before erroring out.")
         response = broker_request(kwargs["broker"], old_route, "delete",
-                                  verify=kwargs["verify"],
+                                  verify=False,
                                   basic_auth_username=kwargs.get("basic_auth_username"),
                                   basic_auth_password=kwargs.get("basic_auth_password"),
                                   auth_token=kwargs.get("auth_token"))
@@ -1259,7 +1259,7 @@ def bootstrap(broker, username, password, token, verify):
 def cmdrun_bootstrap(**kwargs):
     bootstrap(kwargs["broker"], kwargs.get("basic_auth_username"),
               kwargs.get("basic_auth_password"), kwargs.get("auth_token"),
-              kwargs["verify"])
+              False)
 
     if not kwargs['no_relist']:
         relist_service_broker(kwargs)


### PR DESCRIPTION
If this is undesired by the team please let me know. I figured that this flag is only causing more confusion than anything else and I don't know a single person who uses it. Most developers will be working on a cluster with self-signed certs so I don't expect this to work on majority of developer setups.