### PR TITLE
add Bearer string in the request

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -431,7 +431,7 @@ def relist_service_broker(kwargs):
                                                          kwargs['basic_auth_password']))
                        }
         elif kwargs['auth_token'] is not None:
-            headers = {'Authorization': kwargs['auth_token']}
+            headers = {'Authorization': "Bearer " + kwargs['auth_token']}
         else:
             headers = {'Authorization': token}
 
@@ -758,7 +758,7 @@ def broker_request(broker, service_route, method, **kwargs):
                                                          kwargs['basic_auth_password']))
                        }
         elif kwargs['auth_token'] is not None:
-            headers = {'Authorization': kwargs['auth_token']}
+            headers = {'Authorization': "Bearer " + kwargs['auth_token']}
         else:
             token = openshift_client.Configuration().get_api_key_with_prefix('authorization')
             headers = {'Authorization': token}


### PR DESCRIPTION
PR #258 lack of the `Bearer` string in the `Authorization` headers.
Before this PR:
```
[root@localhost config]# oc whoami -t
y3RNSUB4vQv9ANeAokn8BVDi5BRZikoJ99-z7sWmlxI
[root@localhost config]# apb --token y3RNSUB4vQv9ANeAokn8BVDi5BRZikoJ99-z7sWmlxI list
Contacting the ansible-service-broker at: https://asb-1338-openshift-ansible-service-broker.apps.0507-azb.qe.rhcloud.com/ansible-service-broker/v2/catalog
Error: Attempt to list APBs in the broker returned status: 403
Unable to list APBs in Ansible Service Broker.
```

After this PR:
```
[root@localhost hello-world-apb]# apb --token y3RNSUB4vQv9ANeAokn8BVDi5BRZikoJ99-z7sWmlxI list
Contacting the ansible-service-broker at: https://asb-1338-openshift-ansible-service-broker.apps.0507-azb.qe.rhcloud.com/ansible-service-broker/v2/catalog
ID                                NAME               DESCRIPTION                        
2c259ddd8059b9bc65081e07bf20058f  rh-mariadb-apb     Mariadb apb implementation         
03b69500305d9859bb9440d9f9023784  rh-mediawiki-apb   Mediawiki apb implementation       
73ead67495322cc462794387fa9884f5  rh-mysql-apb       Software Collections MySQL APB     
d5915e05b253df421efe6e41fb6a66ba  rh-postgresql-apb  SCL PostgreSQL apb implementation  
```