### PR TITLE
Bug 1572452 - Change --secure option to specify CA cert

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -36,9 +36,16 @@ def subcmd_list_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
@@ -224,9 +231,16 @@ def subcmd_push_parser(subcmd):
         default=u'Dockerfile'
     )
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
@@ -299,9 +313,16 @@ def subcmd_remove_parser(subcmd):
         help=u'ID of APB to remove'
     )
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
@@ -347,9 +368,16 @@ def subcmd_bootstrap_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
@@ -503,9 +531,16 @@ def subcmd_relist_parser(subcmd):
         default=u'ansible-service-broker'
     )
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
@@ -531,9 +566,16 @@ def subcmd_relist_parser(subcmd):
 def subcmd_refresh_parser(subcmd):
     """ version subcommand """
     subcmd.add_argument(
+        '--secure',
+        action='store_true',
+        dest='verify',
+        help=u'Verify SSL connection to Ansible Service Broker',
+        default=False
+    )
+    subcmd.add_argument(
         '--ca-path',
         action='store',
-        dest='verify',
+        dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -47,7 +47,7 @@ def subcmd_list_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--verbose',
@@ -242,7 +242,7 @@ def subcmd_push_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--username',
@@ -324,7 +324,7 @@ def subcmd_remove_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--username',
@@ -379,7 +379,7 @@ def subcmd_bootstrap_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--no-relist',
@@ -542,7 +542,7 @@ def subcmd_relist_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--username',
@@ -577,7 +577,7 @@ def subcmd_refresh_parser(subcmd):
         action='store',
         dest='cert',
         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=False
+        default=None
     )
     subcmd.add_argument(
         '--username',

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -36,10 +36,10 @@ def subcmd_list_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(
@@ -224,10 +224,10 @@ def subcmd_push_parser(subcmd):
         default=u'Dockerfile'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(
@@ -299,10 +299,10 @@ def subcmd_remove_parser(subcmd):
         help=u'ID of APB to remove'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(
@@ -347,10 +347,10 @@ def subcmd_bootstrap_parser(subcmd):
         help=u'Route to the Ansible Service Broker'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(
@@ -503,10 +503,10 @@ def subcmd_relist_parser(subcmd):
         default=u'ansible-service-broker'
     )
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(
@@ -531,10 +531,10 @@ def subcmd_relist_parser(subcmd):
 def subcmd_refresh_parser(subcmd):
     """ version subcommand """
     subcmd.add_argument(
-        '--secure',
-        action='store_true',
+        '--ca-path',
+        action='store',
         dest='verify',
-        help=u'Use secure connection to Ansible Service Broker',
+        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
         default=False
     )
     subcmd.add_argument(

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -746,6 +746,12 @@ def broker_request(broker, service_route, method, **kwargs):
     if not broker.startswith('http'):
         broker = 'https://' + broker
 
+    if kwargs["verify"] is True and kwargs["cert"] is not None:
+        verify = kwargs["cert"]
+    else:
+        verify = kwargs["verify"]
+    print(verify)
+
     url = broker + service_route
     print("Contacting the ansible-service-broker at: %s" % url)
 
@@ -762,7 +768,7 @@ def broker_request(broker, service_route, method, **kwargs):
         else:
             token = openshift_client.Configuration().get_api_key_with_prefix('authorization')
             headers = {'Authorization': token}
-        response = requests.request(method, url, verify=kwargs["verify"],
+        response = requests.request(method, url, verify=verify,
                                     headers=headers, data=kwargs.get("data"))
     except Exception as e:
         print("ERROR: Failed broker request (%s) %s" % (method, url))
@@ -773,7 +779,7 @@ def broker_request(broker, service_route, method, **kwargs):
 
 def cmdrun_list(**kwargs):
     response = broker_request(kwargs['broker'], "/v2/catalog", "get",
-                              verify=kwargs["verify"],
+                              verify=kwargs["verify"], cert=kwargs["cert"],
                               basic_auth_username=kwargs.get("basic_auth_username"),
                               basic_auth_password=kwargs.get("basic_auth_password"),
                               auth_token=kwargs.get("auth_token"))
@@ -1142,7 +1148,7 @@ def cmdrun_push(**kwargs):
     print(spec)
     if kwargs['broker_push']:
         response = broker_request(broker, "/v2/apb", "post", data=data_spec,
-                                  verify=kwargs["verify"],
+                                  verify=kwargs["verify"], cert=kwargs["cert"],
                                   basic_auth_username=kwargs.get("basic_auth_username"),
                                   basic_auth_password=kwargs.get("basic_auth_password"),
                                   auth_token=kwargs.get("auth_token"))
@@ -1165,7 +1171,7 @@ def cmdrun_push(**kwargs):
         kwargs.get("basic_auth_username"),
         kwargs.get("basic_auth_password"),
         kwargs.get("auth_token"),
-        kwargs["verify"]
+        kwargs["verify"], kwargs["cert"]
     )
 
     if not kwargs['no_relist']:
@@ -1209,14 +1215,14 @@ def cmdrun_remove(**kwargs):
             kwargs.get("basic_auth_username"),
             kwargs.get("basic_auth_password"),
             kwargs.get("auth_token"),
-            kwargs["verify"]
+            kwargs["verify"], cert=kwargs["cert"]
         )
         exit()
     else:
         raise Exception("No flag specified.  Use --id or --local.")
 
     response = broker_request(kwargs["broker"], route, "delete",
-                              verify=kwargs["verify"],
+                              verify=kwargs["verify"], cert=kwargs["cert"],
                               basic_auth_username=kwargs.get("basic_auth_username"),
                               basic_auth_password=kwargs.get("basic_auth_password"),
                               auth_token=kwargs.get("auth_token"))
@@ -1225,7 +1231,7 @@ def cmdrun_remove(**kwargs):
         print("Received a 404 trying to remove APB with id: %s" % kwargs["id"])
         print("Attempting to contact 3.7 endpoint before erroring out.")
         response = broker_request(kwargs["broker"], old_route, "delete",
-                                  verify=kwargs["verify"],
+                                  verify=kwargs["verify"], cert=kwargs["cert"],
                                   basic_auth_username=kwargs.get("basic_auth_username"),
                                   basic_auth_password=kwargs.get("basic_auth_password"),
                                   auth_token=kwargs.get("auth_token"))
@@ -1241,9 +1247,9 @@ def cmdrun_remove(**kwargs):
     print("Successfully deleted APB")
 
 
-def bootstrap(broker, username, password, token, verify):
+def bootstrap(broker, username, password, token, verify, cert):
     response = broker_request(broker, "/v2/bootstrap", "post", data={},
-                              verify=verify,
+                              verify=verify, cert=cert,
                               basic_auth_username=username,
                               basic_auth_password=password,
                               auth_token=token)
@@ -1259,7 +1265,7 @@ def bootstrap(broker, username, password, token, verify):
 def cmdrun_bootstrap(**kwargs):
     bootstrap(kwargs["broker"], kwargs.get("basic_auth_username"),
               kwargs.get("basic_auth_password"), kwargs.get("auth_token"),
-              kwargs["verify"])
+              kwargs["verify"], kwargs["cert"])
 
     if not kwargs['no_relist']:
         relist_service_broker(kwargs)

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -746,11 +746,10 @@ def broker_request(broker, service_route, method, **kwargs):
     if not broker.startswith('http'):
         broker = 'https://' + broker
 
-    if kwargs["verify"] is True and kwargs["cert"] is not None:
+    if kwargs["cert"] is not None:
         verify = kwargs["cert"]
     else:
         verify = kwargs["verify"]
-    print(verify)
 
     url = broker + service_route
     print("Contacting the ansible-service-broker at: %s" % url)


### PR DESCRIPTION
Looking [here](http://docs.python-requests.org/en/master/user/advanced/) it appears we were using the `verify` flag as a pure boolean.`verify` can also take in a path to a CA cert to verify connections with. I added a new argument `--ca-path` which now allows the user to pass in the path to a custom CA cert. `--secure` will still set a boolean `True` and will expect that the certs are installed via `certifi` or can be grabbed from a public set of certs (check docs for list).
