### PR TITLE
Bug 1581629 - Fix relist to use --ca-path argument

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -459,12 +459,17 @@ def relist_service_broker(kwargs):
 
         inc_relist_requests = relist_requests + 1
 
+        if kwargs["cert"] is not None:
+            verify = kwargs["cert"]
+        else:
+            verify = kwargs["verify"]
+
         headers['Content-Type'] = 'application/strategic-merge-patch+json'
         response = requests.request(
             "patch",
             broker_resource_url(cluster_host, broker_name),
             json={'spec': {'relistRequests': inc_relist_requests}},
-            verify=kwargs['verify'], headers=headers)
+            verify=verify, headers=headers)
 
         if response.status_code != 200:
             errMsg = "Received non-200 status code while patching relistRequests of broker: {}\n".format(


### PR DESCRIPTION
I forgot to add this to the relist command so bootstrap succeeds but the actual relist fails since `verify` was simply being set to true and not to the CA path.