### PR TITLE
Bug 1581629 - Fix apb relist --secure --ca-path

### DIFF
--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -435,10 +435,15 @@ def relist_service_broker(kwargs):
         else:
             headers = {'Authorization': token}
 
+        if kwargs["cert"] is not None:
+            verify = kwargs["cert"]
+        else:
+            verify = kwargs["verify"]
+
         response = requests.request(
             "get",
             broker_resource_url(cluster_host, broker_name),
-            verify=kwargs['verify'], headers=headers)
+            verify=verify, headers=headers)
 
         if response.status_code != 200:
             errMsg = "Received non-200 status code while retrieving broker: {}\n".format(broker_name) + \
@@ -459,10 +464,6 @@ def relist_service_broker(kwargs):
 
         inc_relist_requests = relist_requests + 1
 
-        if kwargs["cert"] is not None:
-            verify = kwargs["cert"]
-        else:
-            verify = kwargs["verify"]
 
         headers['Content-Type'] = 'application/strategic-merge-patch+json'
         response = requests.request(

--- a/src/apb/engine.py
+++ b/src/apb/engine.py
@@ -464,7 +464,6 @@ def relist_service_broker(kwargs):
 
         inc_relist_requests = relist_requests + 1
 
-
         headers['Content-Type'] = 'application/strategic-merge-patch+json'
         response = requests.request(
             "patch",


### PR DESCRIPTION
If you look at the BZ, `apb relist --ca-path <ca_file>` would succeed while `apb relist --secure --ca-path <ca_file>` would fail. This is because line 441 (446 in new code) was passing the boolean value of `--secure` as opposed to the CA path. I moved the conditional check higher up in the relist function to prevent this.