### PR TITLE
Bug 1585010 - Remove apb refresh as an option

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -22,7 +22,6 @@ AVAILABLE_COMMANDS = {
     'bootstrap': 'Tell Ansible Service Broker to reload APBs from the container repository',
     'test': 'Test the APB',
     'run': 'Run APB',
-    'refresh': 'Refresh all the service-catalog data',
     'version': 'Get current version of APB tool'
 }
 
@@ -559,61 +558,6 @@ def subcmd_relist_parser(subcmd):
         default=None,
         dest='basic_auth_password',
         help=u'Specify the basic auth password to be used'
-    )
-    return
-
-
-def subcmd_refresh_parser(subcmd):
-    """ version subcommand """
-    subcmd.add_argument(
-        '--secure',
-        action='store_true',
-        dest='verify',
-        help=u'Verify SSL connection to Ansible Service Broker',
-        default=False
-    )
-    subcmd.add_argument(
-        '--ca-path',
-        action='store',
-        dest='cert',
-        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-        default=None
-    )
-    subcmd.add_argument(
-        '--username',
-        '-u',
-        action='store',
-        default=None,
-        dest='basic_auth_username',
-        help=u'Specify the basic auth username to be used'
-    )
-    subcmd.add_argument(
-        '--password',
-        '-p',
-        action='store',
-        default=None,
-        dest='basic_auth_password',
-        help=u'Specify the basic auth password to be used'
-    )
-    subcmd.add_argument(
-        '--broker',
-        action='store',
-        dest='broker',
-        help=u'Route to the Ansible Service Broker'
-    )
-    subcmd.add_argument(
-        '--no-relist',
-        action='store_true',
-        dest='no_relist',
-        help=u'Do not relist the catalog after pushing an apb to the broker',
-        default=False
-    )
-    subcmd.add_argument(
-        '--broker-name',
-        action='store',
-        dest='broker_name',
-        help=u'Name of the ServiceBroker k8s resource',
-        default=u'ansible-service-broker'
     )
     return
 

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -23,7 +23,7 @@ AVAILABLE_COMMANDS = {
     'test': 'Test the APB',
     'run': 'Run APB',
     'version': 'Get current version of APB tool'
-#    'refresh': 'Refresh all the service-catalog data',
+    # 'refresh': 'Refresh all the service-catalog data',
 }
 
 
@@ -562,62 +562,62 @@ def subcmd_relist_parser(subcmd):
     )
     return
 
-#Bug 1585010 - Removing apb refresh as a valid option since it currently depends on kubectl being installed
-#We need to revisit this using the dynamic client as opposed to doing a subprocess call.
+# Bug 1585010 - Removing apb refresh as a valid option since it currently depends on kubectl being installed
+# We need to revisit this using the dynamic client as opposed to doing a subprocess call.
 #
-#def subcmd_refresh_parser(subcmd):
-#    """ version subcommand """
-#    subcmd.add_argument(
-#        '--secure',
-#        action='store_true',
-#        dest='verify',
-#        help=u'Verify SSL connection to Ansible Service Broker',
-#        default=False
-#    )
-#    subcmd.add_argument(
-#        '--ca-path',
-#        action='store',
-#        dest='cert',
-#        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
-#        default=None
-#    )
-#    subcmd.add_argument(
-#        '--username',
-#        '-u',
-#        action='store',
-#        default=None,
-#        dest='basic_auth_username',
-#        help=u'Specify the basic auth username to be used'
-#    )
-#    subcmd.add_argument(
-#        '--password',
-#        '-p',
-#        action='store',
-#        default=None,
-#        dest='basic_auth_password',
-#        help=u'Specify the basic auth password to be used'
-#    )
-#    subcmd.add_argument(
-#        '--broker',
-#        action='store',
-#        dest='broker',
-#        help=u'Route to the Ansible Service Broker'
-#    )
-#    subcmd.add_argument(
-#        '--no-relist',
-#        action='store_true',
-#        dest='no_relist',
-#        help=u'Do not relist the catalog after pushing an apb to the broker',
-#        default=False
-#    )
-#    subcmd.add_argument(
-#        '--broker-name',
-#        action='store',
-#        dest='broker_name',
-#        help=u'Name of the ServiceBroker k8s resource',
-#        default=u'ansible-service-broker'
-#    )
-#    return
+# def subcmd_refresh_parser(subcmd):
+#     """ version subcommand """
+#     subcmd.add_argument(
+#         '--secure',
+#         action='store_true',
+#         dest='verify',
+#         help=u'Verify SSL connection to Ansible Service Broker',
+#         default=False
+#     )
+#     subcmd.add_argument(
+#         '--ca-path',
+#         action='store',
+#         dest='cert',
+#         help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
+#         default=None
+#     )
+#     subcmd.add_argument(
+#         '--username',
+#         '-u',
+#         action='store',
+#         default=None,
+#         dest='basic_auth_username',
+#         help=u'Specify the basic auth username to be used'
+#     )
+#     subcmd.add_argument(
+#         '--password',
+#         '-p',
+#         action='store',
+#         default=None,
+#         dest='basic_auth_password',
+#         help=u'Specify the basic auth password to be used'
+#     )
+#     subcmd.add_argument(
+#         '--broker',
+#         action='store',
+#         dest='broker',
+#         help=u'Route to the Ansible Service Broker'
+#     )
+#     subcmd.add_argument(
+#         '--no-relist',
+#         action='store_true',
+#         dest='no_relist',
+#         help=u'Do not relist the catalog after pushing an apb to the broker',
+#         default=False
+#     )
+#     subcmd.add_argument(
+#         '--broker-name',
+#         action='store',
+#         dest='broker_name',
+#         help=u'Name of the ServiceBroker k8s resource',
+#         default=u'ansible-service-broker'
+#     )
+#     return
 
 
 def subcmd_version_parser(subcmd):

--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -23,6 +23,7 @@ AVAILABLE_COMMANDS = {
     'test': 'Test the APB',
     'run': 'Run APB',
     'version': 'Get current version of APB tool'
+#    'refresh': 'Refresh all the service-catalog data',
 }
 
 
@@ -560,6 +561,63 @@ def subcmd_relist_parser(subcmd):
         help=u'Specify the basic auth password to be used'
     )
     return
+
+#Bug 1585010 - Removing apb refresh as a valid option since it currently depends on kubectl being installed
+#We need to revisit this using the dynamic client as opposed to doing a subprocess call.
+#
+#def subcmd_refresh_parser(subcmd):
+#    """ version subcommand """
+#    subcmd.add_argument(
+#        '--secure',
+#        action='store_true',
+#        dest='verify',
+#        help=u'Verify SSL connection to Ansible Service Broker',
+#        default=False
+#    )
+#    subcmd.add_argument(
+#        '--ca-path',
+#        action='store',
+#        dest='cert',
+#        help=u'CA cert to use for verifying SSL connection to Ansible Service Broker',
+#        default=None
+#    )
+#    subcmd.add_argument(
+#        '--username',
+#        '-u',
+#        action='store',
+#        default=None,
+#        dest='basic_auth_username',
+#        help=u'Specify the basic auth username to be used'
+#    )
+#    subcmd.add_argument(
+#        '--password',
+#        '-p',
+#        action='store',
+#        default=None,
+#        dest='basic_auth_password',
+#        help=u'Specify the basic auth password to be used'
+#    )
+#    subcmd.add_argument(
+#        '--broker',
+#        action='store',
+#        dest='broker',
+#        help=u'Route to the Ansible Service Broker'
+#    )
+#    subcmd.add_argument(
+#        '--no-relist',
+#        action='store_true',
+#        dest='no_relist',
+#        help=u'Do not relist the catalog after pushing an apb to the broker',
+#        default=False
+#    )
+#    subcmd.add_argument(
+#        '--broker-name',
+#        action='store',
+#        dest='broker_name',
+#        help=u'Name of the ServiceBroker k8s resource',
+#        default=u'ansible-service-broker'
+#    )
+#    return
 
 
 def subcmd_version_parser(subcmd):


### PR DESCRIPTION
`apb refresh` has a dependency on `kubectl`. Instead of adding another dep I am choosing to not support this for 3.10  since I don't feel its properly tested.

I am leaving the engine logic and simply removing it as a valid CLI option.