### PR TITLE
Corrected name of ASB access ClusterRole

### DIFF
--- a/templates/openshift-permissions.template.yaml
+++ b/templates/openshift-permissions.template.yaml
@@ -18,7 +18,7 @@ objects:
     name: ${USER}
   roleRef:
     kind: ClusterRole
-    name: access-asb-role
+    name: asb-access
     apiGroup: rbac.authorization.k8s.io
 ################################################################################
 # apb must be able to view the ansible-service-broker project


### PR DESCRIPTION
Corrected the name of the ClusterRole that is installed into an OpenShift environment for the developer template