### PR TITLE
support alternative kubeconfig location

### DIFF
--- a/src/apb/cli.py
+++ b/src/apb/cli.py
@@ -4,6 +4,8 @@ import sys
 import argparse
 import pkg_resources
 
+from kubernetes.config import kube_config
+
 import apb.engine
 
 SKIP_OPTIONS = ['provision', 'deprovision', 'bind', 'unbind', 'roles']
@@ -707,6 +709,14 @@ def main():
         dest='base_path',
         help=u'Specify a path to your project. Defaults to CWD.',
         default=os.getcwd()
+    )
+
+    parser.add_argument(
+        '--kubeconfig',
+        action='store',
+        dest='kubeconfig',
+        help=u'OpenShift/Kubernetes configuration file path.',
+        default=kube_config.KUBE_CONFIG_DEFAULT_LOCATION
     )
 
     parser.add_argument(


### PR DESCRIPTION
It will be really helpful for testing to be able to specify custom kubeconfig location. I didn't realize earlier that `--token` alone is not enough for all `apb` functionality.

@jianzhangbjz, I installed patched version on your slave, will appreciate if you can give this some more testing. To test this PR, one would need to remove default `~/.kube/config` file and run the tool commands with `--kubeconfig my/alternative/path`. To make sure that it takes effect properly by all commands.