### PR TITLE
Make initial Dockerfile buildable

### DIFF
--- a/src/apb/dat/Dockerfile.j2
+++ b/src/apb/dat/Dockerfile.j2
@@ -1,6 +1,7 @@
 FROM ansibleplaybookbundle/apb-base
 
 LABEL "com.redhat.apb.spec"=\
+""
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles


### PR DESCRIPTION
Fix unbuildable initial Dockerfile created by `apb init foo` by adding a default value of `""` for the apb spec `LABEL`. 

Previously we could count on the user running `apb prepare` to load ` LABEL "com.redhat.apb.spec"=\	` with a value, but now that we are using APBs (bundles) outside of an Automation Broker context in some scenarios, we don't always expect `apb prepare` to have been a part of the build process.
